### PR TITLE
Fixes auth redirection

### DIFF
--- a/src/js/config.js
+++ b/src/js/config.js
@@ -1,5 +1,5 @@
 const config = {
-  url: 'http://localhost:8080', // your url
+  url: window.location.href,
   flux_url: 'https://flux.io', // flux url
   flux_client_id: '', // your app's client id
 }

--- a/tutorials/chapter_1_login/js/config.js
+++ b/tutorials/chapter_1_login/js/config.js
@@ -1,5 +1,5 @@
 const config = {
-  url: 'http://localhost:8080', // your url
+  url: window.location.href,
   flux_url: 'https://flux.io', // flux url
   flux_client_id: '', // your app's client id
 }

--- a/tutorials/chapter_2_viewport/js/config.js
+++ b/tutorials/chapter_2_viewport/js/config.js
@@ -1,5 +1,5 @@
 const config = {
-  url: 'http://localhost:8080', // your url
+  url: window.location.href,
   flux_url: 'https://flux.io', // flux url
   flux_client_id: '', // your app's client id
 }

--- a/tutorials/chapter_3_read/js/config.js
+++ b/tutorials/chapter_3_read/js/config.js
@@ -1,5 +1,5 @@
 const config = {
-  url: 'http://localhost:8080', // your url
+  url: window.location.href,
   flux_url: 'https://flux.io', // flux url
   flux_client_id: '', // your app's client id
 }

--- a/tutorials/chapter_4_primitives/js/config.js
+++ b/tutorials/chapter_4_primitives/js/config.js
@@ -1,5 +1,5 @@
 const config = {
-  url: 'http://localhost:8080', // your url
+  url: window.location.href,
   flux_url: 'https://flux.io', // flux url
   flux_client_id: '', // your app's client id
 }

--- a/tutorials/chapter_5_write/js/config.js
+++ b/tutorials/chapter_5_write/js/config.js
@@ -1,5 +1,5 @@
 const config = {
-  url: 'http://localhost:8080', // your url
+  url: window.location.href,
   flux_url: 'https://flux.io', // flux url
   flux_client_id: '', // your app's client id
 }

--- a/tutorials/chapter_6_changes/js/config.js
+++ b/tutorials/chapter_6_changes/js/config.js
@@ -1,5 +1,5 @@
 const config = {
-  url: 'http://localhost:8080', // your url
+  url: window.location.href,
   flux_url: 'https://flux.io', // flux url
   flux_client_id: '', // your app's client id
 }


### PR DESCRIPTION
Moving the source code around (i.e., into /src) affected the URLs, since the main tutorial now renders at /src rather than root.

Using `window.location.href` works so long as both the login button/link/what-have-you is located at a route that can also figure out what to do with an authed user - which, in this case, it is for both the "complete" version as well as the chapter versions.
